### PR TITLE
Use get_robot_description to get robot description

### DIFF
--- a/cartesian_controller_base/src/cartesian_controller_base.cpp
+++ b/cartesian_controller_base/src/cartesian_controller_base.cpp
@@ -131,7 +131,7 @@ CartesianControllerBase::on_configure(const rclcpp_lifecycle::State & previous_s
   urdf::Model robot_model;
   KDL::Tree robot_tree;
 
-  m_robot_description = get_node()->get_parameter("robot_description").as_string();
+  m_robot_description = get_robot_description();
   if (m_robot_description.empty())
   {
     RCLCPP_ERROR(get_node()->get_logger(), "robot_description is empty");


### PR DESCRIPTION
This is how it is done in the controllers provided by ros2_control and removes the need to load the parameter in the launch file.